### PR TITLE
fix: 🔊 write logs as json

### DIFF
--- a/cmd/budget2sheets/command.go
+++ b/cmd/budget2sheets/command.go
@@ -18,6 +18,6 @@ func (c *command) process(m events.SQSMessage) error {
 		return err
 	}
 	// Write Transaction to Google Sheets
-	err = c.w.Write(t)
+	err = c.w.Write(t, m.MessageId)
 	return err
 }

--- a/cmd/budget2sheets/command_test.go
+++ b/cmd/budget2sheets/command_test.go
@@ -30,7 +30,7 @@ func getMessage() events.SQSMessage {
 
 func TestProcessWithSuccess(t *testing.T) {
 	w := mock.NewWriter()
-	w.On("Write", budget.NewTransaction("01/01/2020", "<description/>", "<comment/>", "<category/>", 13.37)).Return(nil)
+	w.On("Write", budget.NewTransaction("01/01/2020", "<description/>", "<comment/>", "<category/>", 13.37), "ID").Return(nil)
 
 	cmd := command{r: reader.NewReader(), w: w}
 
@@ -54,7 +54,7 @@ func TestProcessWithReaderError(t *testing.T) {
 
 func TestProcessWithWriterError(t *testing.T) {
 	w := mock.NewWriter()
-	w.On("Write", budget.NewTransaction("01/01/2020", "<description/>", "<comment/>", "<category/>", 13.37)).Return(fmt.Errorf("error for unit test"))
+	w.On("Write", budget.NewTransaction("01/01/2020", "<description/>", "<comment/>", "<category/>", 13.37), "ID").Return(fmt.Errorf("error for unit test"))
 
 	cmd := command{r: reader.NewReader(), w: w}
 

--- a/mock/writer.go
+++ b/mock/writer.go
@@ -15,8 +15,8 @@ type Writer struct {
 	mock.Mock
 }
 
-func (_m *Writer) Write(_a0 budget.Transaction) error {
-	ret := _m.Called(_a0)
+func (_m *Writer) Write(_a0 budget.Transaction, _a1 string) error {
+	ret := _m.Called(_a0, _a1)
 	if ret.Get(0) == nil {
 		return nil
 	}

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -22,9 +22,11 @@ type sqsReader struct {
 }
 
 func (r *sqsReader) Read(m events.SQSMessage) (budget.Transaction, error) {
-	zap.S().Infof("Processing SQS message with id '%v'", m.MessageId)
+	zap.L().Info("Processing SQS message",
+		zap.String("message-id", m.MessageId))
 	var t budget.Transaction
 	err := json.Unmarshal([]byte(m.Body), &t)
-	zap.S().Infof("Processed SQS message with id '%v'", m.MessageId)
+	zap.L().Info("Successfully processed SQS message",
+		zap.String("message-id", m.MessageId))
 	return t, err
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -8,7 +8,7 @@ import (
 
 // Writer is a interface for writing a Transaction objects to Google Sheets
 type Writer interface {
-	Write(t budget.Transaction) error
+	Write(t budget.Transaction, messageId string) error
 }
 
 // NewWriter returns an instances of a writer, actual implementation is not exposed
@@ -22,11 +22,13 @@ type sheetsWriter struct {
 	writeRange    string
 }
 
-func (w *sheetsWriter) Write(t budget.Transaction) error {
-	zap.S().Infof("Processing SQS message with id '%v'", t.Date)
+func (w *sheetsWriter) Write(t budget.Transaction, messageId string) error {
+	zap.L().Info("Processing SQS message",
+		zap.String("message-id", messageId))
 	vr, _ := asValueRange(t)
 	_, err := w.srv.Spreadsheets.Values.Append(w.spreadSheetID, w.writeRange, &vr).ValueInputOption("USER_ENTERED").InsertDataOption("INSERT_ROWS").Do()
-	zap.S().Infof("Processed SQS message with id '%v'", t.Date)
+	zap.L().Info("Successfully processed SQS message",
+		zap.String("message-id", messageId))
 	return err
 }
 


### PR DESCRIPTION
## What?
Update the logs so that the values are written as json

## Why?
This is more convenient when analysing the logs and faster as well when writing the logs.

## How?
Replaced calls to `zap.S().Infof(...)` by `zap.L().Info()`.

## Useful links?
https://www.jbleduigou.com/22/2/21/aws-lambda-pourquoi-%C3%A9crire-des-logs-au-format-json/